### PR TITLE
Add mixin for JSON API partial PUT

### DIFF
--- a/rest_framework_json_api/mixins.py
+++ b/rest_framework_json_api/mixins.py
@@ -1,0 +1,19 @@
+
+class PartialPutMixin(object):
+    """
+    If content type is JSON API, treat PUT as a partial update
+
+    In Django REST Framework:
+    - PUT is a full replacement
+    - PATCH is a partial replacement
+    In JSON API:
+    - PUT is partial replacement with content type "application/vnd.api+json"
+    - PATCH uses JSON Patch format with type "application/json-put+json"
+    """
+
+    def update(self, request, *args, **kwargs):
+        partial = kwargs.pop('partial', False)
+        if request.accepted_media_type == 'application/vnd.api+json':
+            partial = True
+        return super(PartialPutMixin, self).update(
+            request, partial=partial, *args, **kwargs)

--- a/tests/test_mixin.py
+++ b/tests/test_mixin.py
@@ -1,0 +1,64 @@
+"""Test mixins"""
+
+from django.core.urlresolvers import reverse
+from rest_framework_json_api import mixins
+from tests import models
+from tests.utils import dump_json
+from tests.views import PostViewSet
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_drf_put_partial_fails(rf):
+    author = models.Person.objects.create(name="Author")
+    post = models.Post.objects.create(author=author, title="old_title")
+    data = dump_json({
+        "posts": {
+            "title": "new_title"
+        }
+    })
+    result_data = {
+        "author": ["This field is required."]
+    }
+
+    request = rf.put(
+        reverse("post-detail", kwargs={'pk': post.pk}), data=data,
+        content_type="application/vnd.api+json")
+    view = PostViewSet.as_view({'put': 'update'})
+    response = view(request, pk=post.pk)
+    response.render()
+
+    assert response.status_code == 400
+    assert response.data == result_data
+
+
+def test_json_api_put_partial_success(rf):
+
+    class PartialPutPostViewSet(mixins.PartialPutMixin, PostViewSet):
+        pass
+
+    author = models.Person.objects.create(name="Author")
+    post = models.Post.objects.create(author=author, title="old_title")
+    data = dump_json({
+        "posts": {
+            "title": "new_title"
+        }
+    })
+    result_data = {
+        "id": post.pk,
+        "url": "http://testserver/posts/%d/" % post.pk,
+        "title": "new_title",
+        "author": "http://testserver/people/%d/" % author.pk,
+        "comments": [],
+    }
+
+    request = rf.put(
+        reverse("post-detail", kwargs={'pk': post.pk}), data=data,
+        content_type="application/vnd.api+json")
+    view = PartialPutPostViewSet.as_view({'put': 'update'})
+    response = view(request, pk=post.pk)
+    response.render()
+
+    assert response.status_code == 200
+    assert response.data == result_data


### PR DESCRIPTION
This mixin makes PUT `/objects/pk` with "application/vnd.api+json" work with partial representations.
