### PR TITLE
Refactor parser and renderer for extensibility

### DIFF
--- a/rest_framework_json_api/parsers.py
+++ b/rest_framework_json_api/parsers.py
@@ -14,8 +14,8 @@ class JsonApiMixin(object):
 
         view = parser_context.get("view", None)
 
-        model = model_from_obj(view)
-        resource_type = model_to_resource_type(model)
+        model = self.model_from_obj(view)
+        resource_type = self.model_to_resource_type(model)
 
         resource = {}
 
@@ -69,6 +69,12 @@ class JsonApiMixin(object):
                 resource[field_name] = links[field_name]
 
         return resource
+
+    def model_from_obj(self, obj):
+        return model_from_obj(obj)
+
+    def model_to_resource_type(self, model):
+        return model_to_resource_type(model)
 
 
 class JsonApiParser(JsonApiMixin, parsers.JSONParser):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -83,7 +83,7 @@ class JsonApiMixin(object):
 
         # Probably a parser error, unless `detail` is a valid field
         view = renderer_context.get("view", None)
-        model = model_from_obj(view)
+        model = self.model_from_obj(view)
         if 'detail' in model._meta.get_all_field_names():
             raise WrapperNotApplicable()
 
@@ -241,8 +241,8 @@ class JsonApiMixin(object):
         view = renderer_context.get("view", None)
         request = renderer_context.get("request", None)
 
-        model = model_from_obj(view)
-        resource_type = model_to_resource_type(model)
+        model = self.model_from_obj(view)
+        resource_type = self.model_to_resource_type(model)
 
         if isinstance(data, list):
             links = self.dict_class()
@@ -343,7 +343,7 @@ class JsonApiMixin(object):
 
         model = field.opts.model
 
-        resource_type = model_to_resource_type(model)
+        resource_type = self.model_to_resource_type(model)
 
         if field.many:
             obj_ids = []
@@ -412,8 +412,8 @@ class JsonApiMixin(object):
         linked = self.dict_class()
         data = resource.copy()
 
-        model = model_from_obj(field)
-        resource_type = model_to_resource_type(model)
+        model = self.model_from_obj(field)
+        resource_type = self.model_to_resource_type(model)
 
         if field_name in data:
             if "links" not in data:
@@ -441,8 +441,8 @@ class JsonApiMixin(object):
         linked = self.dict_class()
         data = resource.copy()
 
-        model = model_from_obj(field)
-        resource_type = model_to_resource_type(model)
+        model = self.model_from_obj(field)
+        resource_type = self.model_to_resource_type(model)
 
         links[field_name] = {
             "href": self.url_to_template(field.view_name, request, field_name),
@@ -486,6 +486,12 @@ class JsonApiMixin(object):
 
     def fields_from_resource(self, resource):
         return getattr(resource, "fields", None)
+
+    def model_to_resource_type(self, model):
+        return model_to_resource_type(model)
+
+    def model_from_obj(self, obj):
+        return model_from_obj(obj)
 
 
 class JsonApiRenderer(JsonApiMixin, renderers.JSONRenderer):


### PR DESCRIPTION
This is a re-write of PR #11, to address the issues in #7 but without picking a conversion for multi-word resource names.

There are quite a few changes to the code, which makes the full diff useless for seeing what happened.  I didn't change any tests (all pass).  The changes are:
- Functions have been moved to class methods, so that users can override specific methods in derived classes.
- `renderers.JsonApiMixin.renderer` now iterates through wrapper methods by name, stopping when it finds a suitable wrapper and raising an exception if none are suitable.  Users can override an existing wrapper, or add their own.
- Instead of a plain `dict`, a User can specify a different dict-like objects (`SortedDict`, `OrderedDict`) by overriding `renders.JsonApiMixin.wrapper_class`.
- Utility functions are called through class methods, so a user can choose a different algorithm.
- `utils.model_to_resource_type` changed to replace spaces with dashes.
