### PR TITLE
Add util methods for slugifying strings

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -1,4 +1,5 @@
-from django.utils import encoding
+from django.utils.encoding import force_text
+from django.utils.text import slugify
 
 
 def model_from_obj(obj):
@@ -16,7 +17,43 @@ def model_from_obj(obj):
 
 
 def model_to_resource_type(model):
+    '''Return the verbose plural form of a model name, with underscores
+
+    Examples:
+    Person -> "people"
+    ProfileImage -> "profile_image"
+    '''
     if model is None:
         return "data"
 
-    return encoding.force_text(model._meta.verbose_name_plural)
+    return force_text(model._meta.verbose_name_plural)
+
+#
+# String conversion
+#
+
+
+def camelcase(string):
+    '''Return a string in lowerCamelCase
+
+    Examples:
+    "people" -> "people"
+    "profile images" -> "profileImages"
+    '''
+    out = slug(string).replace('-', ' ').title().replace(' ', '')
+    return out[0].lower() + out[1:]
+
+
+def slug(string):
+    '''Return a string where words are connected with hyphens'''
+    return slugify(force_text(string))
+
+
+def snakecase(string):
+    '''Return a string where words are connected with underscores
+
+    Examples:
+    "people" -> "people"
+    "profile images" -> "profile_images"
+    '''
+    return slug(string).replace('-', '_')

--- a/tests/models.py
+++ b/tests/models.py
@@ -23,3 +23,10 @@ class Post(models.Model):
 class Comment(models.Model):
     post = models.ForeignKey(Post, related_name="comments")
     body = models.TextField()
+
+
+class ProfileImage(models.Model):
+    '''A profile image stored in a CDN'''
+    person = models.ForeignKey(Person)
+    url = models.URLField()
+    current = models.BooleanField(db_index=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,23 @@
+from rest_framework_json_api.utils import (
+    camelcase, model_to_resource_type, slug, snakecase)
+from .models import Person, ProfileImage
+
+
+def test_camelcase():
+    assert camelcase('people') == 'people'
+    assert camelcase('profile images') == 'profileImages'
+
+
+def test_slug():
+    assert slug('people') == 'people'
+    assert slug('profile images') == 'profile-images'
+
+
+def test_snakecase():
+    assert snakecase('people') == 'people'
+    assert snakecase('profile images') == 'profile_images'
+
+
+def test_model_to_resource_type():
+    assert model_to_resource_type(Person) == 'people'
+    assert model_to_resource_type(ProfileImage) == 'profile images'


### PR DESCRIPTION
- camelcase makesStringsLookLikeThis
- slug makes-strings-look-like-this
- snakecase makes_strings_look_like_this

When PR #12 is merged, these can be use to pick the default strategy for
resource names with spaces.
