### PR TITLE
Test Python/Django/DRF combinations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,27 @@
 language: python
-
-python:
-  - "2.7"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-
-install: pip install -r requirements.txt -r requirements.test.txt flake8
-
-before_script: python setup.py flake8
-
-script: py.test -vv
-
-notifications:
-  email: false
+install: pip install tox
+script: tox
+env:
+  - TOXENV=py27-django16-drf23
+  - TOXENV=py27-django16-drf24
+  - TOXENV=py27-django16-drf30
+  - TOXENV=py32-django16-drf23
+  - TOXENV=py32-django16-drf24
+  - TOXENV=py32-django16-drf30
+  - TOXENV=py33-django16-drf23
+  - TOXENV=py33-django16-drf24
+  - TOXENV=py33-django16-drf30
+  - TOXENV=py27-django17-drf23
+  - TOXENV=py27-django17-drf24
+  - TOXENV=py27-django17-drf30
+  - TOXENV=py32-django17-drf23
+  - TOXENV=py32-django17-drf24
+  - TOXENV=py32-django17-drf30
+  - TOXENV=py33-django17-drf23
+  - TOXENV=py33-django17-drf24
+  - TOXENV=py33-django17-drf30
+  - TOXENV=py34-django17-drf23
+  - TOXENV=py34-django17-drf24
+  - TOXENV=py34-django17-drf30
+  - TOXENV=style
+  - TOXENV=docs

--- a/conftest.py
+++ b/conftest.py
@@ -56,6 +56,12 @@ def CommentSerializer():
 
 def pytest_configure():
     from django.conf import settings
+    try:
+        # setup from Django 1.7+
+        from django import setup
+    except ImportError:
+        # Not needed in Django 1.6 or less
+        setup = lambda: None
 
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
@@ -92,3 +98,4 @@ def pytest_configure():
             "TEST_REQUEST_DEFAULT_FORMAT": "json",
         },
     )
+    setup()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,6 +1,7 @@
 """Test error response renderer"""
 
 from django.core.urlresolvers import reverse
+from rest_framework.relations import HyperlinkedRelatedField
 from rest_framework.serializers import ValidationError
 from rest_framework.permissions import IsAuthenticated
 
@@ -13,6 +14,14 @@ import pytest
 import rest_framework
 
 pytestmark = pytest.mark.django_db
+
+# "Invalid hyperlink - object does not exist." - DRF 2.x
+# "Invalid hyperlink - Object does not exist." - DRF 3.x
+# Both wrapped in a proxy class that needs to be unproxied
+#  in order to serialized to JSON
+does_not_exist = (
+    HyperlinkedRelatedField.default_error_messages['does_not_exist']
+    .encode('utf-8').decode('utf-8'))
 
 
 def test_required_field_omitted(client):
@@ -154,7 +163,7 @@ def test_invalid_forward_relation(client):
         "errors": [{
             "status": "400",
             "path": "/author",
-            "detail": "Invalid hyperlink - Object does not exist."
+            "detail": does_not_exist
         }]
     }
 
@@ -183,7 +192,7 @@ def test_invalid_reverse_relation(client):
         "errors": [{
             "status": "400",
             "path": "/comments",
-            "detail": "Invalid hyperlink - Object does not exist."
+            "detail": does_not_exist
         }]
     }
 

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -6,6 +6,7 @@ Error tests are in test_errors.py
 
 from django.core.urlresolvers import reverse
 from tests import models
+from tests.serializers import PostSerializer
 from tests.utils import dump_json
 from tests.views import PersonViewSet
 import pytest
@@ -135,6 +136,7 @@ def test_create_post_success(client):
 
 
 def test_options(client):
+    # DRF 3.x representation
     results = {
         "meta": {
             "actions": {
@@ -179,6 +181,11 @@ def test_options(client):
             "renders": ["application/vnd.api+json"],
         }
     }
+
+    # DRF 2.x representation - fields labels are lowercase, no choices
+    ps = PostSerializer()
+    if hasattr(ps, 'metadata'):
+        results['meta']['actions']['POST'] = ps.metadata()
 
     response = client.options(reverse("post-list"))
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,19 @@
 [tox]
-envlist = py27, py32, py33, py34, style, docs
+envlist =
+    py{27,32,33}-django16-drf{23,24,30},
+    py{27,32,33,34}-django17-drf{23,24,30},
+    style,
+    docs
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/drf-json-api
 deps =
-    -r{toxinidir}/requirements.txt
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    drf23: djangorestframework>=2.3,<2.4
+    drf24: djangorestframework>=2.4,<2.5
+    drf30: djangorestframework>=3.0,<3.1
     -r{toxinidir}/requirements.test.txt
 commands =
     py.test --basetemp={envtmpdir}


### PR DESCRIPTION
Use tox to Test combinations of:
- Python 2.7, 3.2, 3.3, and 3.4
- Django 1.5, 1.6, and 1.7
- Django REST Framework 2.3, 2.4, and 3.0

TravisCI changed to call permutations of tox

Tests fixed for DRF 2.3 and 2.4.

Helps with #24.