### PR TITLE
Fix update of linked attributes

### DIFF
--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -387,7 +387,8 @@ class JsonApiMixin(object):
                 data.update(converted.pop("data", {}))
                 linked_ids.update(converted.pop("linked_ids", {}))
                 links.update(converted.get("links", {}))
-                linked.update(converted.get("linked", {}))
+                linked = self.update_nested(linked,
+                                            converted.get('linked', {}))
                 meta.update(converted.get("meta", {}))
             else:
                 data[field_name] = resource[field_name]
@@ -585,6 +586,24 @@ class JsonApiMixin(object):
 
     def model_from_obj(self, obj):
         return model_from_obj(obj)
+
+    def update_nested(self, existing_linked, u):
+        for k, new_values in u.iteritems():
+            if k in existing_linked:
+                # The dictionary already exists, so we need to check
+                # that all the already existing links in the dictionary
+                # aren't the same. If they aren't, add them.
+                for item in new_values:
+                    mapped_ids = map(lambda x: x['id'], existing_linked[k])
+                    if item['id'] in mapped_ids:
+                        print "it's in there already!"
+                    else:
+                        existing_linked[k].append(item)
+
+            else:
+                existing_linked[k] = new_values
+
+        return existing_linked
 
 
 class JsonApiRenderer(JsonApiMixin, renderers.JSONRenderer):

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -387,8 +387,8 @@ class JsonApiMixin(object):
                 data.update(converted.pop("data", {}))
                 linked_ids.update(converted.pop("linked_ids", {}))
                 links.update(converted.get("links", {}))
-                    linked = self.update_nested(linked,
-                                                converted.get('linked', {}))
+                linked = self.update_nested(linked,
+                                            converted.get('linked', {}))
                 meta.update(converted.get("meta", {}))
             else:
                 data[field_name] = resource[field_name]

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -387,8 +387,8 @@ class JsonApiMixin(object):
                 data.update(converted.pop("data", {}))
                 linked_ids.update(converted.pop("linked_ids", {}))
                 links.update(converted.get("links", {}))
-                linked = self.update_nested(linked,
-                                            converted.get('linked', {}))
+                    linked = self.update_nested(linked,
+                                                converted.get('linked', {}))
                 meta.update(converted.get("meta", {}))
             else:
                 data[field_name] = resource[field_name]
@@ -595,9 +595,7 @@ class JsonApiMixin(object):
                 # aren't the same. If they aren't, add them.
                 for item in new_values:
                     mapped_ids = map(lambda x: x['id'], existing_linked[k])
-                    if item['id'] in mapped_ids:
-                        print "it's in there already!"
-                    else:
+                    if not item['id'] in mapped_ids:
                         existing_linked[k].append(item)
 
             else:

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -333,7 +333,8 @@ class JsonApiMixin(object):
             items.append(item)
 
             links.update(converted.get('links', {}))
-            linked.update(converted.get('linked', {}))
+            linked = self.update_nested(linked,
+                                        converted.get('linked', {}))
             meta.update(converted.get('meta', {}))
 
         if many:

--- a/rest_framework_json_api/renderers.py
+++ b/rest_framework_json_api/renderers.py
@@ -588,7 +588,7 @@ class JsonApiMixin(object):
         return model_from_obj(obj)
 
     def update_nested(self, existing_linked, u):
-        for k, new_values in u.iteritems():
+        for k, new_values in u.items():
             if k in existing_linked:
                 # The dictionary already exists, so we need to check
                 # that all the already existing links in the dictionary

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -96,3 +96,73 @@ def test_multiple_linked(client):
     response = client.get(reverse("nested-post-list"))
 
     assert response.content == dump_json(results)
+
+
+def test_multiple_root_entities_linked(client):
+    author = models.Person.objects.create(name="test")
+    post = models.Post.objects.create(
+        author=author, title="One amazing test post.")
+    post2 = models.Post.objects.create(
+        author=author, title="A second amazing test post.")
+    models.Comment.objects.create(
+        post=post, body="This is a test comment.")
+    models.Comment.objects.create(
+        post=post, body="One more comment.")
+    models.Comment.objects.create(
+        post=post2, body="One last comment.")
+
+    results = {
+        "posts": [
+            {
+                "id": "1",
+                "href": "http://testserver/posts/1/",
+                "title": "One amazing test post.",
+                "links": {
+                    "author": "1",
+                    "comments": ["1", "2"],
+                },
+            },
+            {
+                "id": "2",
+                "href": "http://testserver/posts/2/",
+                "title": "One amazing test post.",
+                "links": {
+                    "author": "1",
+                    "comments": ["3"],
+                },
+            },
+        ],
+        "links": {
+            "posts.author": {
+                "href": "http://testserver/people/{posts.author}/",
+                "type": "people",
+            },
+            "posts.comments": {
+                "href": "http://testserver/comments/{posts.comments}/",
+                "type": "comments",
+            }
+        },
+        "linked": {
+            "comments": [
+                {
+                    "id": "1",
+                    "href": "http://testserver/comments/1/",
+                    "body": "This is a test comment.",
+                },
+                {
+                    "id": "2",
+                    "href": "http://testserver/comments/2/",
+                    "body": "One more comment.",
+                },
+                {
+                    "id": "3",
+                    "href": "http://testserver/comments/3/",
+                    "body": "One last comment.",
+                },
+            ],
+        },
+    }
+
+    response = client.get(reverse("nested-post-list"))
+
+    assert response.content == dump_json(results)

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -125,7 +125,7 @@ def test_multiple_root_entities_linked(client):
             {
                 "id": "2",
                 "href": "http://testserver/posts/2/",
-                "title": "One amazing test post.",
+                "title": "A second amazing test post.",
                 "links": {
                     "author": "1",
                     "comments": ["3"],
@@ -162,7 +162,6 @@ def test_multiple_root_entities_linked(client):
             ],
         },
     }
-
     response = client.get(reverse("nested-post-list"))
 
     assert response.content == dump_json(results)


### PR DESCRIPTION
Python's dict update() method doesn't do a deep update of a dictionary,
So the linked dictionary would only show the linked attributes from the
last item. This checks one layer deeper.

Should probably write tests for this.