### PR TITLE
according to the comment for the method, the output should be underscored

### DIFF
--- a/rest_framework_json_api/utils.py
+++ b/rest_framework_json_api/utils.py
@@ -59,7 +59,7 @@ def model_to_resource_type(model):
     if model is None:
         return "data"
 
-    return force_text(model._meta.verbose_name_plural)
+    return snakecase(force_text(model._meta.verbose_name_plural))
 
 #
 # String conversion

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,4 +20,4 @@ def test_snakecase():
 
 def test_model_to_resource_type():
     assert model_to_resource_type(Person) == 'people'
-    assert model_to_resource_type(ProfileImage) == 'profile images'
+    assert model_to_resource_type(ProfileImage) == 'profile_images'


### PR DESCRIPTION
Based on the comments (https://github.com/kevin-brown/drf-json-api/blob/master/rest_framework_json_api/utils.py#L52) the result of this method should not have spaces.
